### PR TITLE
New External Laf Reports

### DIFF
--- a/components/alert-manager.tsx
+++ b/components/alert-manager.tsx
@@ -4,32 +4,29 @@ import { AlertType } from "@/types";
 // AlertManager component
 interface AlertManagerProps {
   alerts: {
+    id: number;
     message: string;
     type: AlertType;
   }[];
   setAlerts: React.Dispatch<
-    React.SetStateAction<{ message: string; type: AlertType }[]>
+    React.SetStateAction<{ id: number; message: string; type: AlertType }[]>
   >;
 }
 
 export default function AlertManager({ alerts, setAlerts }: AlertManagerProps) {
   const removeAlert = (index: number) => {
-    setAlerts((prev) => {
-      const newAlerts = [...prev];
-      newAlerts.splice(index, 1);
-      return newAlerts;
-    });
+    setAlerts((prev) => prev.filter((_, i) => i !== index));
   };
 
   return (
     <div className="fixed max-w-6xl top-4 w-full flex flex-col items-center space-y-4 z-50 left-1/2 transform -translate-x-1/2">
-      {alerts.map((alert, index) => (
+      {alerts.map((alert) => (
         <Alert
-          key={index}
+          key={alert.id}
           variant="flat"
           color={alert.type}
           isClosable
-          onClose={() => removeAlert(index)}
+          onClose={() => removeAlert(alert.id)}
           description=""
           className="flex items-center"
         >

--- a/components/alert-manager.tsx
+++ b/components/alert-manager.tsx
@@ -14,7 +14,11 @@ interface AlertManagerProps {
 
 export default function AlertManager({ alerts, setAlerts }: AlertManagerProps) {
   const removeAlert = (index: number) => {
-    setAlerts((prev) => prev.filter((_, i) => i !== index));
+    setAlerts((prev) => {
+      const newAlerts = [...prev];
+      newAlerts.splice(index, 1);
+      return newAlerts;
+    });
   };
 
   return (

--- a/components/laf/create-lost-report-form.tsx
+++ b/components/laf/create-lost-report-form.tsx
@@ -53,6 +53,7 @@ export default function CreateLostReportForm({
       email: "",
       description: "",
     },
+    mode: "onSubmit",
   });
 
   const [descriptionChange, setDescriptionChange] = useState("");
@@ -186,6 +187,7 @@ export default function CreateLostReportForm({
                 message: "Enter a valid email",
               },
             })}
+            onChange={() => clearErrors("email")}
             errorMessage={errors.email?.message}
             isInvalid={!!errors.email}
           />
@@ -247,9 +249,6 @@ export default function CreateLostReportForm({
             variant="bordered"
             isRequired
             placeholder="Select Location(s)"
-            {...register("location", { required: "Location is required" })}
-            errorMessage={errors.location?.message}
-            isInvalid={!!errors.location}
             items={lafLocations.map((location) => ({
               key: location,
               name: location,

--- a/components/laf/edit-lost-report-modal.tsx
+++ b/components/laf/edit-lost-report-modal.tsx
@@ -64,6 +64,7 @@ export default function EditLostReportModal({
       email: "",
       description: "",
     },
+    mode: "onSubmit",
   });
 
   const { newAlert } = useAlert();
@@ -161,6 +162,7 @@ export default function EditLostReportModal({
                       message: "Enter a valid email",
                     },
                   })}
+                  onChange={() => clearErrors("email")}
                   errorMessage={errors.email?.message}
                   isInvalid={!!errors.email}
                   defaultValue={given_email}
@@ -223,11 +225,6 @@ export default function EditLostReportModal({
                   variant="bordered"
                   isRequired
                   placeholder="Select Location(s)"
-                  {...register("location", {
-                    required: "Location is required",
-                  })}
-                  errorMessage={errors.location?.message}
-                  isInvalid={!!errors.location}
                   items={lafLocations.map((location) => ({
                     key: location,
                     name: location,

--- a/components/laf/found-laf-modal.tsx
+++ b/components/laf/found-laf-modal.tsx
@@ -108,7 +108,7 @@ export default function FoundLAFModal({
   };
 
   return (
-    (<Modal
+    <Modal
       isOpen={isOpen}
       onOpenChange={onOpenChange}
       size="4xl"
@@ -176,6 +176,6 @@ export default function FoundLAFModal({
           </form>
         )}
       </ModalContent>
-    </Modal>)
+    </Modal>
   );
 }

--- a/components/laf/found-laf-modal.tsx
+++ b/components/laf/found-laf-modal.tsx
@@ -48,6 +48,7 @@ export default function FoundLAFModal({
       name: "",
       email: "",
     },
+    mode: "onSubmit",
   });
 
   const { newAlert } = useAlert();
@@ -155,6 +156,7 @@ export default function FoundLAFModal({
                       message: "Enter a valid email",
                     },
                   })}
+                  onChange={() => clearErrors("email")}
                   errorMessage={errors.email?.message}
                   isInvalid={!!errors.email}
                 />

--- a/components/laf/lost-items.tsx
+++ b/components/laf/lost-items.tsx
@@ -51,7 +51,7 @@ export default function LostItems({
     clearErrors,
     handleSubmit,
     formState: { errors },
-  } = useForm<LostItemsFormData>();
+  } = useForm<LostItemsFormData>({ mode: "onSubmit" });
 
   const todaysDate = parseDate(new Date().toISOString().split("T")[0]);
   setValue("date", todaysDate.toString());
@@ -173,9 +173,6 @@ export default function LostItems({
             aria-label="Possible Locations"
             variant="bordered"
             placeholder="Select Location(s)"
-            {...register("location")}
-            errorMessage={errors.location?.message}
-            isInvalid={!!errors.location}
             items={lafLocations.map((location) => ({
               key: location,
               name: location,

--- a/components/laf/lost-reports.tsx
+++ b/components/laf/lost-reports.tsx
@@ -41,7 +41,7 @@ export default function LostReports({
     reset,
     clearErrors,
     formState: { errors },
-  } = useForm<LostReportsFormData>();
+  } = useForm<LostReportsFormData>({ mode: "onSubmit" });
   const { logout, auth } = useAuth();
   const isAuthenticated = auth.isAuthenticated;
 
@@ -137,9 +137,6 @@ export default function LostReports({
             aria-label="Possible Locations"
             variant="bordered"
             placeholder="Select Location(s)"
-            {...register("location", { required: "Location is required" })}
-            errorMessage={errors.location?.message}
-            isInvalid={!!errors.location}
             items={lafLocations.map((location) => ({
               key: location,
               name: location,
@@ -227,7 +224,10 @@ export default function LostReports({
             })}
             errorMessage={errors.email?.message}
             isInvalid={!!errors.email}
-            onChange={(e) => handleChange("email", e.target.value)}
+            onChange={(e) => {
+              handleChange("email", e.target.value);
+              clearErrors("email");
+            }}
           />
         </div>
         {/* Description Field */}

--- a/components/laf/new-lost-reports.tsx
+++ b/components/laf/new-lost-reports.tsx
@@ -63,13 +63,12 @@ export default function NewLostReports({
   const [items, setItems] = useState<LAFItem[]>([]);
 
   const handleSelectionChange = (selection: Selection) => {
-    console.log("Selection change: ", selection);
     setSelectedItem(selection);
   };
 
   const markAsViewed = async () => {
     if (selectedItem === null) {
-      console.error("No item selected");
+      console.error("No lost report selected");
       newAlert("No lost report selected", "danger");
       return;
     }
@@ -102,9 +101,18 @@ export default function NewLostReports({
   };
 
   useEffect(() => {
+    let interval: NodeJS.Timeout | null = null;
     if (isAuthenticated && view === "New Lost Reports") {
       fetchLostReportItems({}, setLostReportItems, logout, true);
+      interval = setInterval(() => {
+        fetchLostReportItems({}, setLostReportItems, logout, true);
+      }, 15000);
     }
+    return () => {
+      if (interval) {
+        clearInterval(interval);
+      }
+    };
   }, [view]);
 
   useEffect(() => {

--- a/components/laf/new-lost-reports.tsx
+++ b/components/laf/new-lost-reports.tsx
@@ -1,0 +1,152 @@
+import {
+  Table,
+  TableHeader,
+  TableColumn,
+  TableBody,
+  TableRow,
+  TableCell,
+  getKeyValue,
+  Chip,
+} from "@heroui/react";
+import { useEffect, useState } from "react";
+import { Selection } from "@react-types/shared";
+import { useAuth } from "@/context/AuthContext";
+import { fetchLostReportItems, fetchLAFItems } from "@/utils/laf/utils";
+import { LostReportItem } from "@/types/laf";
+import LAFItems from "./laf-items";
+import { LAFItem } from "@/types/laf";
+
+interface NewLostReportsProps {
+  view: string;
+}
+
+export default function NewLostReports({ view }: NewLostReportsProps) {
+  const { logout, auth } = useAuth();
+  const isAuthenticated = auth.isAuthenticated;
+
+  const columns = [
+    {
+      key: "type",
+      label: "Type",
+    },
+    {
+      key: "location",
+      label: "Locations",
+    },
+    {
+      key: "description",
+      label: "Description",
+    },
+    {
+      key: "date",
+      label: "Date",
+    },
+    {
+      key: "name",
+      label: "Name",
+    },
+    {
+      key: "email",
+      label: "Email",
+    },
+    {
+      key: "actions",
+      label: "Actions",
+    },
+  ];
+
+  const [lostReportItems, setLostReportItems] = useState<LostReportItem[]>([]);
+  const [selectedItem, setSelectedItem] = useState<Selection | null>(null);
+  const [items, setItems] = useState<LAFItem[]>([]);
+
+  const handleSelectionChange = (selection: Selection) => {
+    console.log("Selection change: ", selection);
+    setSelectedItem(selection);
+  };
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      if (view !== "New Lost Reports") {
+        fetchLostReportItems({}, setLostReportItems, logout, true);
+      }
+    }
+  }, [view]);
+
+  useEffect(() => {
+    if (selectedItem) {
+      console.log("Selected Item: ", selectedItem);
+      const selectedReport = lostReportItems.find(
+        (item) => item.id === Array.from(selectedItem)[0]
+      );
+      if (selectedReport === undefined) {
+        setSelectedItem(null);
+        setItems([]);
+      } else {
+        console.log("Selected Report: ", selectedReport);
+        const formData: Record<string, string> = {
+          type: selectedReport.type,
+          location: selectedReport.location.join(", "),
+          description: selectedReport.description,
+        };
+        console.log("Form Data: ", formData);
+        fetchLAFItems(formData, setItems, logout);
+        console.log("Items: ", items);
+      }
+    }
+  }, [selectedItem]);
+
+  return (
+    <>
+      <Table
+        aria-label="LAF Items"
+        className="my-5"
+        isStriped
+        selectionMode="single"
+        color="primary"
+        onSelectionChange={handleSelectionChange}
+      >
+        <TableHeader columns={columns}>
+          {(column) => (
+            <TableColumn key={column.key}>{column.label}</TableColumn>
+          )}
+        </TableHeader>
+        <TableBody
+          items={lostReportItems}
+          emptyContent={"No New Lost Reports found."}
+        >
+          {(item) => (
+            <TableRow key={item.id}>
+              {(columnKey) => (
+                <TableCell>
+                  {columnKey == "actions" ? (
+                    <p>View</p>
+                  ) : columnKey === "id" ? (
+                    item.type.charAt(0) + item.id
+                  ) : columnKey === "location" ? (
+                    item.location.map((loc, index) => (
+                      <Chip key={index} className="mr-1 my-1">
+                        {loc}
+                      </Chip>
+                    ))
+                  ) : (
+                    getKeyValue(item, columnKey)
+                  )}
+                </TableCell>
+              )}
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+      <h2 className="text-center mt-5 text-3xl">
+        Potential Matching LAF items
+      </h2>
+      <LAFItems
+        items={items}
+        lafTypes={[]}
+        lafLocations={[]}
+        updateTable={() => {}}
+        edit={false}
+      />
+    </>
+  );
+}

--- a/components/laf/selector.tsx
+++ b/components/laf/selector.tsx
@@ -1,19 +1,47 @@
 import { ViewState } from "@/types/laf";
+import { useEffect, useState } from "react";
+import { Badge } from "@heroui/react";
 
 interface LAFSelectorProps {
   setView: React.Dispatch<React.SetStateAction<ViewState>>;
-  views: ViewState[];
   view: ViewState;
 }
 
-export default function LAFSelector({
-  setView,
-  views,
-  view,
-}: LAFSelectorProps) {
+export default function LAFSelector({ setView, view }: LAFSelectorProps) {
+  const views: ViewState[] = [
+    "Found Item",
+    "Lost Items",
+    "Submit Lost Report",
+    "Find Lost Report",
+    "New Lost Reports",
+    "Expired Items",
+    // "Archive",
+  ];
+
   const changeSelector = (view: ViewState) => {
     setView(view);
   };
+
+  const [newLostReports, setNewLostReports] = useState(0);
+
+  const fetchNewLostReports = async () => {
+    const data = await fetch(
+      `${process.env.NEXT_PUBLIC_BACKEND_SERVER}/laf/report/new/count`,
+      {
+        credentials: "include",
+      }
+    );
+    if (data.ok) {
+      const json = await data.json();
+      setNewLostReports(json.data);
+    }
+  };
+
+  useEffect(() => {
+    fetchNewLostReports();
+    const interval = setInterval(fetchNewLostReports, 15000);
+    return () => clearInterval(interval);
+  }, [view]);
 
   return (
     <div className="flex items-center justify-center my-10">
@@ -23,13 +51,24 @@ export default function LAFSelector({
             key={index}
             onClick={() => changeSelector(item)}
             className={`flex-1 mx-1 py-2 px-2 rounded-full text-center transition-all duration-300 
-            ${
-              view === item
-                ? "bg-blue-500 shadow-md text-black"
-                : "bg-transparent text-gray-700"
-            }`}
+              ${
+                view === item
+                  ? "bg-blue-500 shadow-md text-black"
+                  : "bg-transparent text-gray-700"
+              }`}
           >
-            {item}
+            {item !== "New Lost Reports" && item}
+            {item === "New Lost Reports" && newLostReports === 0 && item}
+            {item === "New Lost Reports" && newLostReports > 0 && (
+              <Badge
+                color="danger"
+                className="ml-2"
+                content={newLostReports}
+                showOutline={false}
+              >
+                {item}
+              </Badge>
+            )}
           </button>
         ))}
       </div>

--- a/components/laf/selector.tsx
+++ b/components/laf/selector.tsx
@@ -5,9 +5,14 @@ import { Badge } from "@heroui/react";
 interface LAFSelectorProps {
   setView: React.Dispatch<React.SetStateAction<ViewState>>;
   view: ViewState;
+  newLostReports: number;
 }
 
-export default function LAFSelector({ setView, view }: LAFSelectorProps) {
+export default function LAFSelector({
+  setView,
+  view,
+  newLostReports,
+}: LAFSelectorProps) {
   const views: ViewState[] = [
     "Found Item",
     "Lost Items",
@@ -21,27 +26,6 @@ export default function LAFSelector({ setView, view }: LAFSelectorProps) {
   const changeSelector = (view: ViewState) => {
     setView(view);
   };
-
-  const [newLostReports, setNewLostReports] = useState(0);
-
-  const fetchNewLostReports = async () => {
-    const data = await fetch(
-      `${process.env.NEXT_PUBLIC_BACKEND_SERVER}/laf/reports/new/count`,
-      {
-        credentials: "include",
-      }
-    );
-    if (data.ok) {
-      const json = await data.json();
-      setNewLostReports(json.data);
-    }
-  };
-
-  useEffect(() => {
-    fetchNewLostReports();
-    const interval = setInterval(fetchNewLostReports, 15000);
-    return () => clearInterval(interval);
-  }, [view]);
 
   return (
     <div className="flex items-center justify-center my-10">

--- a/components/laf/selector.tsx
+++ b/components/laf/selector.tsx
@@ -26,7 +26,7 @@ export default function LAFSelector({ setView, view }: LAFSelectorProps) {
 
   const fetchNewLostReports = async () => {
     const data = await fetch(
-      `${process.env.NEXT_PUBLIC_BACKEND_SERVER}/laf/report/new/count`,
+      `${process.env.NEXT_PUBLIC_BACKEND_SERVER}/laf/reports/new/count`,
       {
         credentials: "include",
       }

--- a/components/loanertech/checkOutModal.tsx
+++ b/components/loanertech/checkOutModal.tsx
@@ -100,7 +100,7 @@ export default function CheckOutModalContent({
   };
 
   return (
-    (<Modal
+    <Modal
       isOpen={isOpen}
       onOpenChange={onOpenChange}
       size="xl"
@@ -142,6 +142,7 @@ export default function CheckOutModalContent({
                     message: "Enter a valid email",
                   },
                 })}
+                onChange={() => clearErrors("email")}
                 errorMessage={errors.email?.message}
                 isInvalid={!!errors.email}
               />
@@ -167,6 +168,6 @@ export default function CheckOutModalContent({
           </form>
         )}
       </ModalContent>
-    </Modal>)
+    </Modal>
   );
 }

--- a/config/site.ts
+++ b/config/site.ts
@@ -99,5 +99,9 @@ export const siteConfig = {
       label: "Wiki",
       href: "https://wiki.apoez.org/",
     },
+    {
+      label: "Money Tool",
+      href: "https://sites.google.com/apoez.org/apoezmoneytool/home",
+    },
   ],
 };

--- a/context/AlertContext.tsx
+++ b/context/AlertContext.tsx
@@ -14,13 +14,17 @@ interface AlertProviderrProps {
 export function AlertProvider({ children }: AlertProviderrProps) {
   const [alerts, setAlerts] = useState<
     {
+      id: number;
       message: string;
       type: AlertType;
     }[]
   >([]);
 
   const newAlert = (alert: string, type: AlertType) => {
-    setAlerts((prev) => [...prev, { message: alert, type: type }]);
+    setAlerts((prev) => [
+      ...prev,
+      { id: Date.now(), message: alert, type: type },
+    ]);
   };
 
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -9911,6 +9911,111 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.1.6.tgz",
+      "integrity": "sha512-x1jGpbHbZoZ69nRuogGL2MYPLqohlhnT9OCU6E6QFewwup+z+M6r8oU47BTeJcWsF2sdBahp5cKiAcDbwwK/lg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.1.6.tgz",
+      "integrity": "sha512-jar9sFw0XewXsBzPf9runGzoivajeWJUc/JkfbLTC4it9EhU8v7tCRLH7l5Y1ReTMN6zKJO0kKAGqDk8YSO2bg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.1.6.tgz",
+      "integrity": "sha512-+n3u//bfsrIaZch4cgOJ3tXCTbSxz0s6brJtU3SzLOvkJlPQMJ+eHVRi6qM2kKKKLuMY+tcau8XD9CJ1OjeSQQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.1.6.tgz",
+      "integrity": "sha512-SpuDEXixM3PycniL4iVCLyUyvcl6Lt0mtv3am08sucskpG0tYkW1KlRhTgj4LI5ehyxriVVcfdoxuuP8csi3kQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.1.6.tgz",
+      "integrity": "sha512-L4druWmdFSZIIRhF+G60API5sFB7suTbDRhYWSjiw0RbE+15igQvE2g2+S973pMGvwN3guw7cJUjA/TmbPWTHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.1.6.tgz",
+      "integrity": "sha512-s8w6EeqNmi6gdvM19tqKKWbCyOBvXFbndkGHl+c9YrzsLARRdCHsD9S1fMj8gsXm9v8vhC8s3N8rjuC/XrtkEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.1.6.tgz",
+      "integrity": "sha512-6xomMuu54FAFxttYr5PJbEfu96godcxBTRk1OhAvJq0/EnmFU/Ybiax30Snis4vdWZ9LGpf7Roy5fSs7v/5ROQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/pages/laf/index.tsx
+++ b/pages/laf/index.tsx
@@ -7,6 +7,7 @@ import NewLostReport from "@/components/laf/create-lost-report";
 import LostItems from "@/components/laf/lost-items";
 import LostReports from "@/components/laf/lost-reports";
 import ExpiredItems from "@/components/laf/expired-items";
+import NewLostReports from "@/components/laf/new-lost-reports";
 import { useAuth } from "@/context/AuthContext";
 import { ViewState } from "@/types/laf";
 
@@ -102,7 +103,7 @@ export default function LAFPage({ lafTypes, lafLocations }: LAFPageProps) {
               display: view === "New Lost Reports" ? "block" : "none",
             }}
           >
-            <p>Matching Lost Reports in progress</p>
+            <NewLostReports view={view} />
           </div>
           <div
             style={{

--- a/pages/laf/index.tsx
+++ b/pages/laf/index.tsx
@@ -36,16 +36,6 @@ export default function LAFPage({ lafTypes, lafLocations }: LAFPageProps) {
     checkAuthStatus();
   }, [view]);
 
-  const views: ViewState[] = [
-    "Found Item",
-    "Lost Items",
-    "Submit Lost Report",
-    "Find Lost Report",
-    // "Matching Lost Reports",
-    "Expired Items",
-    // "Archive",
-  ];
-
   const [switchToLostReport, setSwitchToLostReport] = useState<Record<
     string,
     string
@@ -58,7 +48,7 @@ export default function LAFPage({ lafTypes, lafLocations }: LAFPageProps) {
       </div>
       {!loading && isAuthenticated && (
         <>
-          <LAFSelector view={view} setView={setView} views={views} />
+          <LAFSelector view={view} setView={setView} />
           <div
             style={{
               display: view === "Found Item" ? "block" : "none",
@@ -109,7 +99,7 @@ export default function LAFPage({ lafTypes, lafLocations }: LAFPageProps) {
           </div>
           <div
             style={{
-              display: view === "Matching Lost Reports" ? "block" : "none",
+              display: view === "New Lost Reports" ? "block" : "none",
             }}
           >
             <p>Matching Lost Reports in progress</p>

--- a/pages/laf/index.tsx
+++ b/pages/laf/index.tsx
@@ -23,6 +23,20 @@ export default function LAFPage({ lafTypes, lafLocations }: LAFPageProps) {
   const [view, setView] = useState<ViewState>("Found Item");
   const [loading, setLoading] = useState(true);
 
+  const [newLostReports, setNewLostReports] = useState(0);
+  const fetchNewLostReports = async () => {
+    const data = await fetch(
+      `${process.env.NEXT_PUBLIC_BACKEND_SERVER}/laf/reports/new/count`,
+      {
+        credentials: "include",
+      }
+    );
+    if (data.ok) {
+      const json = await data.json();
+      setNewLostReports(json.data);
+    }
+  };
+
   useEffect(() => {
     if (lafTypes && lafLocations) {
       setLoading(false);
@@ -31,6 +45,9 @@ export default function LAFPage({ lafTypes, lafLocations }: LAFPageProps) {
 
   useEffect(() => {
     checkAuthStatus();
+    fetchNewLostReports();
+    const interval = setInterval(fetchNewLostReports, 15000);
+    return () => clearInterval(interval);
   }, []);
 
   useEffect(() => {
@@ -49,7 +66,11 @@ export default function LAFPage({ lafTypes, lafLocations }: LAFPageProps) {
       </div>
       {!loading && isAuthenticated && (
         <>
-          <LAFSelector view={view} setView={setView} />
+          <LAFSelector
+            view={view}
+            setView={setView}
+            newLostReports={newLostReports}
+          />
           <div
             style={{
               display: view === "Found Item" ? "block" : "none",
@@ -103,7 +124,10 @@ export default function LAFPage({ lafTypes, lafLocations }: LAFPageProps) {
               display: view === "New Lost Reports" ? "block" : "none",
             }}
           >
-            <NewLostReports view={view} />
+            <NewLostReports
+              view={view}
+              fetchNewLostReports={fetchNewLostReports}
+            />
           </div>
           <div
             style={{

--- a/types/laf.ts
+++ b/types/laf.ts
@@ -3,7 +3,7 @@ export type ViewState =
   | "Lost Items"
   | "Submit Lost Report"
   | "Find Lost Report"
-  | "Matching Lost Reports"
+  | "New Lost Reports"
   | "Expired Items"
   | "Archive"
   | "error";

--- a/utils/laf/utils.tsx
+++ b/utils/laf/utils.tsx
@@ -60,20 +60,22 @@ export async function fetchLAFItems(
 export async function fetchLostReportItems(
   formData: Record<string, string>,
   setLostReportItems: React.Dispatch<React.SetStateAction<LostReportItem[]>>,
-  logout: () => void
+  logout: () => void,
+  newReports: boolean = false
 ) {
   // Prepare params based on form data
   const params = await convertFormToParams(formData);
 
   try {
     // Make the fetch request
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_BACKEND_SERVER}/laf/reports/?${params}`,
-      {
-        method: "GET",
-        credentials: "include",
-      }
-    );
+    const url = newReports
+      ? `${process.env.NEXT_PUBLIC_BACKEND_SERVER}/laf/reports/new`
+      : `${process.env.NEXT_PUBLIC_BACKEND_SERVER}/laf/reports/?${params}`;
+
+    const response = await fetch(url, {
+      method: "GET",
+      credentials: "include",
+    });
 
     if (response.ok) {
       const response_data = await response.json();


### PR DESCRIPTION
Add page to view external lost reports. and fix some validation errors in LAF forms
OP#62
OP#64

- **update things**
- **Add New Lost Reports**
- **move view state into laf selector**
- **update component to have a badge for new lost reports**
- **add functionality to use function with new lost reports**
- **add New Lost Reports component**
- **add Money Tool**
- **Try to fix alert manager to remove only the alerts you remove**
- **fix route**
- **New Lost Reports component**
- **move logic out of selector so that it can be used when updating new lost reports**
- **cleanup**
- **Complete main functionality of new external lost reports page**
- **add logic for retrieving new lost report counts**
- **use date.now() as a unique id for alerts to prevent remove alert issues**
- **add interval to update items and end interval when not on the page**
- **cleanup forms and fix issues with validations**
