### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -13,6 +13,9 @@ on:
       - "Dockerfile"
       - ".dockerignore"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -8,6 +8,9 @@ on:
       - "**.ts"
       - "**.tsx"
 
+permissions:
+  contents: read
+
 jobs:
   eslint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/alpha-phi-omega-ez/frontend/security/code-scanning/5](https://github.com/alpha-phi-omega-ez/frontend/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since this is a linting workflow, it only needs read access to the repository contents. We will set `contents: read` as the minimal required permission. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
