### PR TITLE
Potential fix for code scanning alert no. 3: Client-side cross-site scripting

### DIFF
--- a/.github/workflows/typescriptcheck.yml
+++ b/.github/workflows/typescriptcheck.yml
@@ -1,0 +1,26 @@
+name: TypeScript Check
+
+on:
+  pull_request:
+    paths:
+      - "**.ts"
+      - "**.tsx"
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typescript check
+        run: tsc --noEmit

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 next-env.d.ts
 
 .vscode
+
+public/robots.txt
+public/*.xml

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build && next-sitemap",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "check": "next lint && tsc --noEmit"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/pages/login/callback/index.tsx
+++ b/pages/login/callback/index.tsx
@@ -10,9 +10,15 @@ export default function CallBackPage() {
   const [error, setError] = useState(false);
   const { newAlert } = useAlert();
 
-  function sanitizeRedirectPath(path: string) {
-    // Allow only paths starting with "/" and disallow any external URLs
-    if (path && path.startsWith("/") && !path.startsWith("//")) {
+  function sanitizeRedirectPath(path: string | null) {
+    // Allow only paths starting with "/" and disallow any external URLs, path traversal, or embedded protocols
+    if (
+      path &&
+      path.startsWith("/") &&
+      !path.startsWith("//") &&
+      !path.includes("..") &&
+      !path.includes(":")
+    ) {
       return path;
     }
     return null; // Default to null if the path is invalid

--- a/pages/login/callback/index.tsx
+++ b/pages/login/callback/index.tsx
@@ -10,7 +10,7 @@ export default function CallBackPage() {
   const [error, setError] = useState(false);
   const { newAlert } = useAlert();
 
-  function sanitizeRedirectPath(path) {
+  function sanitizeRedirectPath(path: string) {
     // Allow only paths starting with "/" and disallow any external URLs
     if (path && path.startsWith("/") && !path.startsWith("//")) {
       return path;

--- a/pages/login/callback/index.tsx
+++ b/pages/login/callback/index.tsx
@@ -10,10 +10,18 @@ export default function CallBackPage() {
   const [error, setError] = useState(false);
   const { newAlert } = useAlert();
 
+  function sanitizeRedirectPath(path) {
+    // Allow only paths starting with "/" and disallow any external URLs
+    if (path && path.startsWith("/") && !path.startsWith("//")) {
+      return path;
+    }
+    return null; // Default to null if the path is invalid
+  }
+
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);
     const code = urlParams.get("code");
-    const redirectPath = urlParams.get("redirect") || "/";
+    const redirectPath = sanitizeRedirectPath(urlParams.get("redirect")) || "/";
 
     if (code) {
       fetch(`${process.env.NEXT_PUBLIC_BACKEND_SERVER}/token`, {


### PR DESCRIPTION
Potential fix for [https://github.com/alpha-phi-omega-ez/frontend/security/code-scanning/3](https://github.com/alpha-phi-omega-ez/frontend/security/code-scanning/3)

To fix the issue, we need to validate and sanitize the `redirectPath` variable before using it in `router.push()`. A common approach is to maintain a whitelist of allowed paths or ensure that the path starts with a safe prefix (e.g., `/`). If the `redirect` parameter does not meet the validation criteria, we should default to a safe fallback, such as `/`.

Steps to implement the fix:
1. Add a validation function to check if the `redirectPath` is safe.
2. Use this function to sanitize the `redirectPath` before passing it to `router.push()`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
